### PR TITLE
cache decompressed stored fields

### DIFF
--- a/load.go
+++ b/load.go
@@ -33,13 +33,14 @@ func load(data *segment.Data) (*Segment, error) {
 		return nil, fmt.Errorf("error parsing footer: %w", err)
 	}
 	rv := &Segment{
-		data:           data.Slice(0, data.Len()-footerLen),
-		footer:         footer,
-		fieldsMap:      make(map[string]uint16),
-		fieldDvReaders: make(map[uint16]*docValueReader),
-		fieldFSTs:      make(map[uint16]*vellum.FST),
-		fieldDocs:      make(map[uint16]uint64),
-		fieldFreqs:     make(map[uint16]uint64),
+		data:                          data.Slice(0, data.Len()-footerLen),
+		footer:                        footer,
+		fieldsMap:                     make(map[string]uint16),
+		fieldDvReaders:                make(map[uint16]*docValueReader),
+		fieldFSTs:                     make(map[uint16]*vellum.FST),
+		decompressedStoredFieldChunks: make(map[uint64][]byte),
+		fieldDocs:                     make(map[uint16]uint64),
+		fieldFreqs:                    make(map[uint16]uint64),
 	}
 
 	// FIXME temporarily map to existing footer fields

--- a/new.go
+++ b/new.go
@@ -88,16 +88,17 @@ func initSegmentBase(mem []byte, footer *footer,
 	fieldsDocs, fieldsFreqs map[uint16]uint64,
 	dictLocs []uint64, storedFieldChunkOffsets []uint64) (*Segment, error) {
 	sb := &Segment{
-		data:                    segment.NewDataBytes(mem),
-		footer:                  footer,
-		fieldsMap:               fieldsMap,
-		fieldsInv:               fieldsInv,
-		fieldDocs:               fieldsDocs,
-		fieldFreqs:              fieldsFreqs,
-		dictLocs:                dictLocs,
-		fieldDvReaders:          make(map[uint16]*docValueReader),
-		fieldFSTs:               make(map[uint16]*vellum.FST),
-		storedFieldChunkOffsets: storedFieldChunkOffsets,
+		data:                          segment.NewDataBytes(mem),
+		footer:                        footer,
+		fieldsMap:                     fieldsMap,
+		fieldsInv:                     fieldsInv,
+		fieldDocs:                     fieldsDocs,
+		fieldFreqs:                    fieldsFreqs,
+		dictLocs:                      dictLocs,
+		fieldDvReaders:                make(map[uint16]*docValueReader),
+		fieldFSTs:                     make(map[uint16]*vellum.FST),
+		decompressedStoredFieldChunks: make(map[uint64][]byte),
+		storedFieldChunkOffsets:       storedFieldChunkOffsets,
 	}
 	sb.updateSize()
 

--- a/segment.go
+++ b/segment.go
@@ -40,8 +40,7 @@ type Segment struct {
 	fieldDocs  map[uint16]uint64 // fieldID -> # docs with value in field
 	fieldFreqs map[uint16]uint64 // fieldID -> # total tokens in field
 
-	storedFieldChunkOffsets      []uint64 // stored field chunk offset
-	storedFieldChunkUncompressed []byte   // for uncompress cache
+	storedFieldChunkOffsets []uint64 // stored field chunk offset
 
 	dictLocs       []uint64
 	fieldDvReaders map[uint16]*docValueReader // naive chunk cache per field
@@ -49,8 +48,9 @@ type Segment struct {
 	size           uint64
 
 	// state loaded dynamically
-	m         sync.Mutex
-	fieldFSTs map[uint16]*vellum.FST
+	m                             sync.Mutex
+	fieldFSTs                     map[uint16]*vellum.FST
+	decompressedStoredFieldChunks map[uint64][]byte
 }
 
 func (s *Segment) WriteTo(w io.Writer, _ chan struct{}) (int64, error) {


### PR DESCRIPTION
this is one approach to make the decompressing of a chunk of
stored fields work safely (no data race) and efficiently

the approach is to cache the decompressed buffer for each chunk
the advantage is that we only decompress it once
and it can avoid data races with a mutex

the disadvantage of this approach is that could waste considerable
memory as the most likely the compressed and decompressed
versions will remain in memory as long as the segment is open